### PR TITLE
fix typo in Presto variant extract test

### DIFF
--- a/sqlglot/tests/dialects/test_presto.py
+++ b/sqlglot/tests/dialects/test_presto.py
@@ -1349,7 +1349,7 @@ MATCH_RECOGNIZE (
             self.assertEqual(s.sql(dialect), json_extract_result)
             self.assertEqual(s.sql(dialect_json_extract_setting), json_extract_result)
 
-            # If the setting is overriden to False, then generate ROW access (dot notation)
+            # If the setting is overridden to False, then generate ROW access (dot notation)
             self.assertEqual(
                 s.sql(dialect_row_access_setting), 'SELECT col.x.y."special string"'
             )


### PR DESCRIPTION
## Summary
- fix typo in Presto dialect tests

## Testing
- `pytest sqlglot/tests/dialects/test_presto.py::TestPresto::test_json_vs_row_extract -q`


------
https://chatgpt.com/codex/tasks/task_e_68968c45acc4832798c06adb825fe233