### PR TITLE
docs: fix ast types path reference

### DIFF
--- a/AST_TYPES_COMPLETION_SUMMARY.md
+++ b/AST_TYPES_COMPLETION_SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `symbo-ast/ast_types.py` file has been successfully completed with full support for all BigQuery node types as specified in the BigQueryLexicalIdentifiers.md documentation.
+The `lib/types.py` file has been successfully completed with full support for all BigQuery node types as specified in the BigQueryLexicalIdentifiers.md documentation.
 
 ## What Was Accomplished
 
@@ -168,7 +168,7 @@ The completed AST types can be used to:
 
 ## Conclusion
 
-The `symbo-ast/ast_types.py` file now provides complete, production-ready support for all BigQuery language constructs. This implementation enables developers to:
+The `lib/types.py` file now provides complete, production-ready support for all BigQuery language constructs. This implementation enables developers to:
 
 - Parse and generate BigQuery SQL programmatically
 - Build custom SQL analysis and transformation tools

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bigquery-ast-types/
 
 ## Overview
 
-The `symbo-ast/ast_types.py` file has been successfully completed with full support for all BigQuery node types as specified in the BigQueryLexicalIdentifiers.md documentation.
+The `lib/types.py` file has been successfully completed with full support for all BigQuery node types as specified in the BigQueryLexicalIdentifiers.md documentation.
 
 ## What Was Accomplished
 
@@ -231,7 +231,7 @@ The completed AST types can be used to:
 
 ## Conclusion
 
-The `symbo-ast/ast_types.py` file now provides complete, production-ready support for all BigQuery language constructs. This implementation enables developers to:
+The `lib/types.py` file now provides complete, production-ready support for all BigQuery language constructs. This implementation enables developers to:
 
 - Parse and generate BigQuery SQL programmatically
 - Build custom SQL analysis and transformation tools


### PR DESCRIPTION
## Summary
- update references to ast types path in docs

## Testing
- `pytest` *(fails: No module named 'bigquery_ast_types', No module named 'pytz', No module named 'duckdb', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68968c49bc448327a6fca69a6f0f926d