### PR TITLE
Add optional dependencies for tests and examples

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,26 @@ setup(
         "sqlglot>=25.0.0",
     ],
     extras_require={
+        "tests": [
+            "pytest>=7.0",
+            "pytz",
+            "duckdb",
+            "numpy",
+            "pandas",
+        ],
+        "examples": [
+            "pendulum",
+        ],
         "dev": [
             "pytest>=7.0",
             "black>=22.0",
             "mypy>=1.0",
             "ruff>=0.0.261",
+            "pytz",
+            "duckdb",
+            "numpy",
+            "pandas",
+            "pendulum",
         ],
     },
 )


### PR DESCRIPTION
## Summary
- document external libraries used in examples and tests
- expose these extras in `setup.py`

## Testing
- `pip install -e .[tests]` *(failed: Could not find a version that satisfies the requirement setuptools>=40.8.0 (ProxyError))*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bigquery_ast_types', 'pytz', 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_68968f30974c83279c93d7c6783775d3