### PR TITLE
Add basic clause and literal builders

### DIFF
--- a/lib/serializer.py
+++ b/lib/serializer.py
@@ -242,6 +242,10 @@ class SQLSerializer(ASTVisitor):
             if i > 0:
                 self._write(", ")
             expr.accept(self)
+        if node.rollup:
+            self._write(" WITH ROLLUP")
+        elif node.cube:
+            self._write(" WITH CUBE")
 
     def visit_having_clause(self, node: HavingClause) -> Any:
         """
@@ -263,6 +267,8 @@ class SQLSerializer(ASTVisitor):
         node.expression.accept(self)
         if node.direction:
             self._write(f" {node.direction.value}")
+        if node.nulls_first is not None:
+            self._write(" NULLS FIRST" if node.nulls_first else " NULLS LAST")
 
     def visit_order_by_clause(self, node: OrderByClause) -> Any:
         """

--- a/lib/types.py
+++ b/lib/types.py
@@ -792,6 +792,8 @@ class WhereClause(ASTNode):
 class GroupByClause(ASTNode):
     """GROUP BY clause."""
     expressions: List[Expression] = field(default_factory=list)
+    rollup: bool = False
+    cube: bool = False
 
     def accept(self, visitor: "ASTVisitor") -> Any:
         return visitor.visit_group_by_clause(self)
@@ -809,12 +811,18 @@ class OrderByItem(ASTNode):
     """Single ORDER BY item."""
     expression: Expression
     direction: OrderDirection = OrderDirection.ASC
+    nulls_first: Optional[bool] = None
 
     def accept(self, visitor: "ASTVisitor") -> Any:
         return visitor.visit_order_by_item(self)
 
     def __str__(self) -> str:
-        return f"{self.expression} {self.direction.value}"
+        parts = [str(self.expression)]
+        if self.direction:
+            parts.append(self.direction.value)
+        if self.nulls_first is not None:
+            parts.append("NULLS FIRST" if self.nulls_first else "NULLS LAST")
+        return " ".join(parts)
 
 @dataclass
 class OrderByClause(ASTNode):


### PR DESCRIPTION
## Summary
- add builders for GROUP BY, HAVING, ORDER BY, LIMIT, INTERVAL, JSON literals, and named parameters
- support NULLS FIRST/LAST and ROLLUP/CUBE flags in AST and serializer
- test new builders

## Testing
- `pytest` *(fails: ValueError parsing literals and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6896f19fa5848327b3967d87ce9fe3ce